### PR TITLE
Bugfix ShareRelay (ZeroMQ) needs .NET core 2.1

### DIFF
--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -55,12 +55,12 @@
 
     <!-- Conditionally for the .NETcore 2.1 target -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" />
+        
     </ItemGroup>
 
     <!-- Conditionally for the .NETcore 3.1 target -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+
     </ItemGroup>
 
     
@@ -87,6 +87,7 @@
     <PackageReference Include="NBitcoin" Version="4.1.2.22" />
     <PackageReference Include="NBitcoin.Zcash" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.1" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="NLog" Version="4.6.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.0" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Miningcore</AssemblyName>
     <RootNamespace>Miningcore</RootNamespace>

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -87,7 +87,7 @@
     <PackageReference Include="NBitcoin" Version="4.1.2.22" />
     <PackageReference Include="NBitcoin.Zcash" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.1" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="NLog" Version="4.6.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.0" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
     <PackageReference Include="MailKit" Version="2.1.4" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Miningcore</AssemblyName>
     <RootNamespace>Miningcore</RootNamespace>
     <Platforms>AnyCPU</Platforms>
@@ -52,13 +52,13 @@
   </ItemGroup>
 
     <!-- Conditionally for the .NETcore 2.2 target -->
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json"  />
     </ItemGroup>
 
     <!-- Conditionally for the .NETcore 3.1 target -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     </ItemGroup>
 
     
@@ -72,7 +72,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
     <PackageReference Include="MailKit" Version="2.1.4" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
     <PackageReference Include="MailKit" Version="2.1.4" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Miningcore</AssemblyName>
     <RootNamespace>Miningcore</RootNamespace>
     <Platforms>AnyCPU</Platforms>
@@ -51,7 +51,18 @@
     <None Remove="config2.json" />
   </ItemGroup>
 
-  <ItemGroup>
+    <!-- Conditionally for the .NETcore 2.2 target -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json"  />
+    </ItemGroup>
+
+    <!-- Conditionally for the .NETcore 3.1 target -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    </ItemGroup>
+
+    
+    <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="3.0.4" />
     <PackageReference Include="Autofac" Version="4.9.2" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
@@ -61,17 +72,17 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
     <PackageReference Include="MailKit" Version="2.1.4" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.0" />
     <PackageReference Include="morelinq" Version="3.1.1" />
     <PackageReference Include="NBitcoin" Version="4.1.2.22" />
     <PackageReference Include="NBitcoin.Zcash" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="NLog" Version="4.6.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.0" />
     <PackageReference Include="Npgsql" Version="4.0.6" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Miningcore</AssemblyName>
     <RootNamespace>Miningcore</RootNamespace>
     <Platforms>AnyCPU</Platforms>

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Miningcore</AssemblyName>
     <RootNamespace>Miningcore</RootNamespace>
     <Platforms>AnyCPU</Platforms>
@@ -147,4 +147,9 @@
       <ContentWithTargetPath Include="@(Libs->'%(FullPath)')" RelativePath="%(Libs.Identity)" TargetPath="%(Libs.Filename)%(Libs.Extension)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+      <Exec Command="echo Output written to $(TargetDir)" />
+  </Target>
+
 </Project>

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -52,19 +52,8 @@
     <None Remove="config.json" />
     <None Remove="config2.json" />
   </ItemGroup>
-
-    <!-- Conditionally for the .NETcore 2.1 target -->
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-        
-    </ItemGroup>
-
-    <!-- Conditionally for the .NETcore 3.1 target -->
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-
-    </ItemGroup>
-
     
-    <ItemGroup>
+  <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="3.0.4" />
     <PackageReference Include="Autofac" Version="4.9.2" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
@@ -148,10 +137,6 @@
       <Libs Include="$(OutDir)libmultihash.so;$(OutDir)libcryptonote.so;$(OutDir)libcryptonight.so" />
       <ContentWithTargetPath Include="@(Libs->'%(FullPath)')" RelativePath="%(Libs.Identity)" TargetPath="%(Libs.Filename)%(Libs.Extension)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-      <Exec Command="echo Output written to $(TargetDir)" />
   </Target>
 
 </Project>

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -30,6 +30,7 @@
     <StartupObject>Miningcore.Program</StartupObject>
     <Company>Miningcore.com</Company>
     <Version>1.0.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -54,7 +55,7 @@
 
     <!-- Conditionally for the .NETcore 2.1 target -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json"  />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" />
     </ItemGroup>
 
     <!-- Conditionally for the .NETcore 3.1 target -->

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -51,7 +51,7 @@
     <None Remove="config2.json" />
   </ItemGroup>
 
-    <!-- Conditionally for the .NETcore 2.2 target -->
+    <!-- Conditionally for the .NETcore 2.1 target -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json"  />
     </ItemGroup>
@@ -73,11 +73,15 @@
     <PackageReference Include="MailKit" Version="2.1.4" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.AspNetCore.All" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.12" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.12" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.12" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="morelinq" Version="3.1.1" />
     <PackageReference Include="NBitcoin" Version="4.1.2.22" />
     <PackageReference Include="NBitcoin.Zcash" Version="3.0.0" />

--- a/src/Miningcore/Miningcore.csproj
+++ b/src/Miningcore/Miningcore.csproj
@@ -78,7 +78,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.12" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.12" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />

--- a/src/Miningcore/Program.cs
+++ b/src/Miningcore/Program.cs
@@ -729,7 +729,7 @@ namespace Miningcore
                     services.AddSingleton((IComponentContext) container);
                     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
-#if netcore2_2
+#if netcore2_1
                     services.AddMvc()
                         .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
                         .AddControllersAsServices()
@@ -787,7 +787,7 @@ namespace Miningcore
                     app.UseWebSockets();
                     app.MapWebSocketManager("/notifications", app.ApplicationServices.GetService<WebSocketNotificationsRelay>());
                     app.UseMetricServer();
-#if netcore2_2
+#if netcore2_1
                     app.UseMvc();
 #endif
 #if netcore3_1

--- a/src/Miningcore/Program.cs
+++ b/src/Miningcore/Program.cs
@@ -731,7 +731,7 @@ namespace Miningcore
 
 #if netcore2_1
                     services.AddMvc()
-                        .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                        .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                         .AddControllersAsServices()
                         .AddJsonOptions(options =>
                         {

--- a/src/Miningcore/Program.cs
+++ b/src/Miningcore/Program.cs
@@ -729,6 +729,17 @@ namespace Miningcore
                     services.AddSingleton((IComponentContext) container);
                     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
+#if netcore2_2
+                    services.AddMvc()
+                        .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                        .AddControllersAsServices()
+                        .AddJsonOptions(options =>
+                        {
+                            options.SerializerSettings.Formatting = Formatting.Indented;
+                        });
+#endif
+
+#if netcore3_1
                     services.AddControllers()
                         .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                         .AddControllersAsServices()
@@ -736,6 +747,8 @@ namespace Miningcore
                         {
                             options.SerializerSettings.Formatting = Formatting.Indented;
                         });
+#endif
+
 
                     // .ContractResolver = new DefaultContractResolver());
 
@@ -774,12 +787,16 @@ namespace Miningcore
                     app.UseWebSockets();
                     app.MapWebSocketManager("/notifications", app.ApplicationServices.GetService<WebSocketNotificationsRelay>());
                     app.UseMetricServer();
-                    //app.UseMvc();
+#if netcore2_2
+                    app.UseMvc();
+#endif
+#if netcore3_1
                     app.UseRouting();
                     app.UseEndpoints(endpoints => {
                         endpoints.MapDefaultControllerRoute();
                         endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
                     });
+#endif
                 })
                 .UseKestrel(options =>
                 {

--- a/src/Miningcore/linux-build-core21.sh
+++ b/src/Miningcore/linux-build-core21.sh
@@ -6,4 +6,4 @@ echo ""
 sudo apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5
 BUILDIR=${1:-../../build}
 echo "Building into $BUILDIR"
-dotnet publish -c Release --framework netcoreapp3.1 -o $BUILDIR
+dotnet publish -c Release --framework netcoreapp2.1 -o $BUILDIR

--- a/src/Miningcore/linux-build-core21.sh
+++ b/src/Miningcore/linux-build-core21.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo ""
+echo "The following dev-dependencies must be installed"
+echo "Ubuntu: apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5"
+echo ""
+sudo apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5
+BUILDIR=${1:-../../build}
+echo "Building into $BUILDIR"
+dotnet publish -c Release --framework netcoreapp3.1 -o $BUILDIR

--- a/src/Miningcore/linux-build.sh
+++ b/src/Miningcore/linux-build.sh
@@ -4,6 +4,14 @@ echo "The following dev-dependencies must be installed"
 echo "Ubuntu: apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5"
 echo ""
 sudo apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5
+
+echo .
+echo "Installing dotnet SDK core 3.1"
+sudo apt-get update; \
+  sudo apt-get install -y apt-transport-https && \
+  sudo apt-get update && \
+  sudo apt-get install -y dotnet-sdk-3.1
+
 BUILDIR=${1:-../../build}
 echo "Building into $BUILDIR"
 dotnet publish -c Release --framework netcoreapp3.1 -o $BUILDIR

--- a/src/Miningcore/linux-x64-build-netcore21.sh
+++ b/src/Miningcore/linux-x64-build-netcore21.sh
@@ -4,6 +4,14 @@ echo "The following dev-dependencies must be installed"
 echo "Ubuntu: apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5"
 echo ""
 sudo apt-get install git cmake build-essential libssl-dev pkg-config libboost-all-dev libsodium-dev libzmq5
+
+echo .
+echo "Installing dotnet SDK core 2.1"
+sudo apt-get update; \
+  sudo apt-get install -y apt-transport-https && \
+  sudo apt-get update && \
+  sudo apt-get install -y dotnet-sdk-2.1
+
 BUILDIR=${1:-../../build}
 echo "Building into $BUILDIR"
-dotnet publish -c Release --framework netcoreapp2.1 -o $BUILDIR
+dotnet publish -c Release --framework netcoreapp2.1 --runtime linux-x64 --self-contained true -o $BUILDIR


### PR DESCRIPTION
**Bugfix ShareRelay (ZeroMQ) needs .NET core 2.1 runtime**
ZeroMQ is not supported in .NET core 3.1 and ShareRelay will fail

If you need ShareRelay support:
- Install dotnet-sdk-2.1
```
sudo apt-get update; \
  sudo apt-get install -y apt-transport-https && \
  sudo apt-get update && \
  sudo apt-get install -y dotnet-sdk-2.1
```
- Build pool in core2.1 framework
```
BUILDIR=${1:-../../build}
echo "Building into $BUILDIR"
dotnet publish -c Release --framework netcoreapp2.1 --runtime linux-x64 --self-contained true -o $BUILDIR
```
  
  