### PR TITLE
connect to ssl only database

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $ exit
 
 - Import Miningcore database tables
 ````console
-sudo wget https://raw.githubusercontent.com/minernl/miningcore/master/src/Miningcore/Persistence/Postgres/Scripts/createdb.sql
+sudo wget https://raw.githubusercontent.com/minernl/miningcore/master/src/Miningcore/DataStore/Postgres/Scripts/createdb.sql
 
 sudo -u postgres -i
 psql -d miningcore -f createdb.sql

--- a/src/Miningcore/Configuration/ClusterConfig.cs
+++ b/src/Miningcore/Configuration/ClusterConfig.cs
@@ -396,6 +396,10 @@ namespace Miningcore.Configuration
     public class DatabaseConfig : AuthenticatedNetworkEndpointConfig
     {
         public string Database { get; set; }
+        /// <summary>
+        /// Use SSL
+        /// </summary>
+        public bool Ssl { get; set; }
     }
 
     public class TcpProxyProtocolConfig

--- a/src/Miningcore/DataStore/Postgres/PostgresInterface.cs
+++ b/src/Miningcore/DataStore/Postgres/PostgresInterface.cs
@@ -67,6 +67,10 @@ namespace Miningcore.DataStore.Postgres
 
             // build connection string
             var connectionString = $"Server={pgConfig.Host};Port={pgConfig.Port};Database={pgConfig.Database};User Id={pgConfig.User};Password={pgConfig.Password};CommandTimeout=900;";
+            
+            // concatenate SSL config to connectionString
+            if(pgConfig.Ssl == true)
+                connectionString += "SSL Mode=Require;Trust Server Certificate=True;Server Compatibility Mode=Redshift;";
 
             // register connection factory
             builder.RegisterInstance(new PgConnectionFactory(connectionString))


### PR DESCRIPTION
add an `ssl` variable to the persistence config, this allows miningcore to run and connect to an ssl required connection. for example, connect to [Digital Ocean's managed Database](https://www.digitalocean.com/products/managed-databases/)